### PR TITLE
Revert "Add $ to $value key when passing request to Klaviyo"

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -50,8 +50,7 @@ exports.track = function(track){
 /**
  * Map Completed Order
  *
- * Original Docs (NO LONGER WORKING): http://docs.klaviyo.com/article/60-ecommerce-integrating-a-custom-cart
- * Update from Neill Silva at Klaviyo (support@klaviyo.com): Move $event_id out of order.properties to order obj
+ * Docs: http://docs.klaviyo.com/article/60-ecommerce-integrating-a-custom-cart
  *
  * @param {Track} track
  * @return {Object} Returns an object with two properties: .order (Object) and .products (Object[]). Each individual object should be sent in its own call to Klaviyo's API.
@@ -66,7 +65,6 @@ exports.completedOrder = function(track, settings){
   var payloads = {};
 
   payloads.order = {
-    $event_id: track.orderId(),
     token: settings.apiKey,
     event: 'Placed Order',
     time: time(track.timestamp())
@@ -77,6 +75,7 @@ exports.completedOrder = function(track, settings){
   };
 
   payloads.order.properties = {
+    $event_id: track.orderId(),
     $value: track.revenue(),
     Categories: categories,
     'Item Names': productNames,
@@ -86,7 +85,6 @@ exports.completedOrder = function(track, settings){
   payloads.products = products.map(function(item){
     var product = new Track({ properties: item });
     var productPayload = {
-      $event_id: product.id() || track.orderId() + '_' + product.sku(),
       token: settings.apiKey,
       event: 'Ordered Product',
       time: time(track.timestamp())
@@ -95,6 +93,7 @@ exports.completedOrder = function(track, settings){
       $id: track.userId() || track.sessionId()
     };
     productPayload.properties = {
+      $event_id: product.id() || track.orderId() + '_' + product.sku(),
       $value: product.price(),
       Name: product.name(),
       Quantity: product.quantity(),
@@ -176,7 +175,7 @@ function formatItems(products){
 
 function properties(track){
   return extend(track.properties(), {
-    $value: track.revenue()
+    value: track.revenue()
   });
 }
 

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -22,7 +22,7 @@
       "property": true,
       "email": "johndoe@segment.io",
       "revenue": 19.99,
-      "$value": 19.99
+      "value": 19.99
     }
   }
 }

--- a/test/fixtures/track-completed-order-urls.json
+++ b/test/fixtures/track-completed-order-urls.json
@@ -34,11 +34,11 @@
     "order": {
       "token" : "hfWBjc",
       "event" : "Placed Order",
-      "$event_id" : "order-id",
       "customer_properties" : {
         "$id": "user-id"
       },
       "properties" : {
+        "$event_id" : "order-id",
         "$value" : 50.00,
         "Categories" : ["gaming", "console"],
         "Item Names" : ["sony pulse", "sony playstation 4"],
@@ -69,10 +69,10 @@
       {
         "token": "hfWBjc",
         "event": "Ordered Product",
-        "$event_id": 123,
         "time": 1388534400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
+          "$event_id": 123,
           "$value": 20,
           "Name": "sony pulse",
           "Product Categories": ["gaming"],
@@ -86,8 +86,8 @@
         "event": "Ordered Product",
         "time": 1388534400,
         "customer_properties": { "$id": "user-id" },
-        "$event_id": 455,
         "properties": {
+          "$event_id": 455,
           "$value": 30,
           "Name": "sony playstation 4",
           "Product Categories": ["console"],

--- a/test/fixtures/track-completed-order.json
+++ b/test/fixtures/track-completed-order.json
@@ -32,11 +32,11 @@
     "order": {
       "token" : "hfWBjc",
       "event" : "Placed Order",
-      "$event_id" : "order-id",
       "customer_properties" : {
         "$id": "user-id"
       },
       "properties" : {
+        "$event_id" : "order-id",
         "$value" : 50.00,
         "Categories" : ["gaming", "console"],
         "Item Names" : ["sony pulse", "sony playstation 4"],
@@ -65,10 +65,10 @@
       {
         "token": "hfWBjc",
         "event": "Ordered Product",
-        "$event_id": 123,
         "time": 1388534400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
+          "$event_id": 123,
           "$value": 20,
           "Name": "sony pulse",
           "Product Categories": ["gaming"],
@@ -78,10 +78,10 @@
       {
         "token": "hfWBjc",
         "event": "Ordered Product",
-        "$event_id": 455,
         "time": 1388534400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
+          "$event_id": 455,
           "$value": 30,
           "Name": "sony playstation 4",
           "Product Categories": ["console"],


### PR DESCRIPTION
Reverts segmentio/integration-klaviyo#3

Realized moving `$event_id` up to the top level object isn't exactly what the support rep from klaviyo articulated, which was to remove it from the `data` object entirely. We'll need a bit more clarification on how to handle that change.
