### PR TITLE
Update how value is passed to Klaviyo

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -175,7 +175,7 @@ function formatItems(products){
 
 function properties(track){
   return extend(track.properties(), {
-    value: track.revenue()
+    $value: track.revenue()
   });
 }
 

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -22,7 +22,7 @@
       "property": true,
       "email": "johndoe@segment.io",
       "revenue": 19.99,
-      "value": 19.99
+      "$value": 19.99
     }
   }
 }


### PR DESCRIPTION
Correctly prefixes value with `$`, picked from @francisco's original PR #3 
