### PR TITLE
map special prop `$event_id` in conventional track calls

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -168,14 +168,22 @@ function formatItems(products){
 /**
  * Format track properties.
  *
+ * Populate $event_id via `properties.eventId` alias,
+ * falling back to a copy of `properties.orderId`.
+ *
+ * If neither is present, omit from payload.
+ *
  * @param {Track} track
  * @return {Object}
  * @api private
  */
 
 function properties(track){
-  return extend(track.properties(), {
-    $value: track.revenue()
+  return extend(track.properties({
+    'eventId': '$event_id'
+  }), {
+    $value: track.revenue(),
+    $event_id: track.orderId()
   });
 }
 

--- a/test/fixtures/track-eventId.json
+++ b/test/fixtures/track-eventId.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "some-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "email": "johndoe@segment.io",
+      "property": true,
+      "eventId": "12314234"
+    }
+  },
+  "output": {
+    "token": "hfWBjc",
+    "event": "some-event",
+    "time": 1388534400,
+    "customer_properties": {
+      "$id": "user-id",
+      "$email": "johndoe@segment.io"
+    },
+    "properties": {
+      "property": true,
+      "email": "johndoe@segment.io",
+      "revenue": 19.99,
+      "$value": 19.99,
+      "$event_id": "12314234"
+    }
+  }
+}

--- a/test/fixtures/track-orderId.json
+++ b/test/fixtures/track-orderId.json
@@ -1,0 +1,31 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "some-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "email": "johndoe@segment.io",
+      "property": true,
+      "orderId": "12314234"
+    }
+  },
+  "output": {
+    "token": "hfWBjc",
+    "event": "some-event",
+    "time": 1388534400,
+    "customer_properties": {
+      "$id": "user-id",
+      "$email": "johndoe@segment.io"
+    },
+    "properties": {
+      "property": true,
+      "email": "johndoe@segment.io",
+      "revenue": 19.99,
+      "$value": 19.99,
+      "$event_id": "12314234",
+      "orderId": "12314234"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,14 @@ describe('Klaviyo', function () {
         test.maps('track-basic', settings);
       });
 
+      it('should map orderId to $eventId', function(){
+        test.maps('track-orderId', settings);
+      });
+
+      it('should map eventId to $eventId', function(){
+        test.maps('track-eventId', settings);
+      });
+
       it('should map completed order', function() {
         test.maps('track-completed-order', settings);
       });


### PR DESCRIPTION
Previously, we were only setting this on `Completed Order` calls, but it serves a purpose in conventional `track` calls as well: https://www.klaviyo.com/docs/http-api#special-event-properties

Can be populated via either `properties.eventId` or `properties.orderId`.
