### PR TITLE
add support for list api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ var Batch = require('batch');
  */
 
 var Klaviyo = module.exports = integration('Klaviyo')
-  .endpoint('http://a.klaviyo.com/api')
+  .endpoint('https://a.klaviyo.com/api')
   .ensure('settings.apiKey')
   .channels(['server'])
   .mapper(mapper)
@@ -29,7 +29,32 @@ var Klaviyo = module.exports = integration('Klaviyo')
  * @api public
  */
 
-Klaviyo.prototype.identify = request('/identify');
+Klaviyo.prototype.identify = function(msg, fn) {
+  var self = this;
+
+  this
+    .get('/identify')
+    .query({ data: new Buffer(JSON.stringify(msg.peopleData)).toString('base64') })
+    .end(function(err, res){
+      if (err) return fn(err);
+
+      // 1 = success 0 = failure
+      if (res.text != '1') {
+        err = self.error('bad response');
+        return fn(err, res);
+      }
+
+      if (!msg.listData) return fn(null, res);
+
+      // https://www.klaviyo.com/docs/api/lists
+      // Add this person to a List
+      self
+        .post('/v1/list/' + msg.listId + '/members') // upsertion endpoint
+        .type('form')
+        .send(msg.listData)
+        .end(fn);
+    });
+};
 
 /**
  * Track.
@@ -92,7 +117,7 @@ Klaviyo.prototype.check = function(fn){
   var self = this;
   return this.handle(function(err, res){
     if (err) return fn(err);
-    if ('1' != res.text) err = self.error('bad response');
+    if (res.text != '1') err = self.error('bad response');
     return fn(err, res);
   });
 };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -6,6 +6,7 @@
 var extend = require('extend');
 var time = require('unix-time');
 var Track = require('segmentio-facade').Track;
+var reject = require('reject');
 
 /**
  * Map identify.
@@ -18,10 +19,25 @@ var Track = require('segmentio-facade').Track;
  */
 
 exports.identify = function(identify){
-  return {
-    token: this.settings.apiKey,
-    properties: traits(identify)
+  var opts = identify.options(this.name);
+  var msg = {
+    peopleData: {
+      token: this.settings.apiKey,
+      properties: traits(identify)
+    }
   };
+
+  // email, listId, and api_key all required
+  if (opts.listId && identify.email() && this.settings.privateKey) {
+    msg.listId = opts.listId;
+    msg.listData = {
+      email: identify.email(),
+      api_key: this.settings.privateKey,
+      confirm_optin: opts.confirmOptin != undefined ? opts.confirmOptin : this.settings.confirmOptin // default setting is true, can be overriden per event via options
+    };
+  }
+
+  return msg;
 };
 
 /**
@@ -181,7 +197,7 @@ function properties(track){
 
 /**
  * Format traits.
- *
+ * https://www.klaviyo.com/docs/api/people
  * @param {Identify} identify
  * @return {Object}
  * @api private
@@ -189,14 +205,19 @@ function properties(track){
 
 function traits(identify){
   var traits = identify.traits();
-  return extend(traits, {
+  // why are we extending and not removing duplicate traits here?
+  return reject(extend(traits, {
     $id: identify.userId() || identify.sessionId(),
     $email: identify.email(),
     $first_name: identify.firstName(),
     $last_name: identify.lastName(),
     $phone_number: identify.phone(),
-    $title: identify.proxy('traits.title'),
+    $title: identify.proxy('traits.title') || identify.position(),
     $organization: identify.proxy('traits.organization'),
-    $company: identify.proxy('traits.company')
-  });
+    $city: identify.city(),
+    $region: identify.region() || identify.state(),
+    $country: identify.country(),
+    $timezone: identify.timezone(),
+    $zip: identify.zip()
+  }));
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "batch": "^0.5.2",
     "extend": "^2.0.0",
+    "reject": "0.0.1",
     "segmentio-integration": "^3.2.0",
     "unix-time": "^1.0.1"
   },

--- a/test/fixtures/identify-anonymous-id.json
+++ b/test/fixtures/identify-anonymous-id.json
@@ -14,24 +14,25 @@
     }
   },
   "output": {
-    "token": "hfWBjc",
-    "properties": {
-      "$id": "user-id",
-      "$email": "johndoe@segment.io",
-      "$first_name": "John",
-      "$last_name": "Doe",
-      "$phone_number": "5555",
-      "$title": "some-title",
-      "$organization": "org",
-      "$company": "segment",
-      "email": "johndoe@segment.io",
-      "firstName": "John",
-      "lastName": "Doe",
-      "phone": "5555",
-      "title": "some-title",
-      "some-trait": "value",
-      "organization": "org",
-      "company": "segment"
+    "peopleData": {
+      "token": "hfWBjc",
+      "properties": {
+        "$id": "user-id",
+        "$email": "johndoe@segment.io",
+        "$first_name": "John",
+        "$last_name": "Doe",
+        "$phone_number": "5555",
+        "$title": "some-title",
+        "$organization": "org",
+        "email": "johndoe@segment.io",
+        "firstName": "John",
+        "lastName": "Doe",
+        "phone": "5555",
+        "title": "some-title",
+        "some-trait": "value",
+        "organization": "org",
+        "company": "segment"
+      }
     }
   }
 }

--- a/test/fixtures/identify-list-override.json
+++ b/test/fixtures/identify-list-override.json
@@ -2,27 +2,25 @@
   "input": {
     "type": "identify",
     "userId": "01293721",
-    "context": {
-      "timezone": "Europe/Amsterdam"
-    },
     "traits": {
       "email": "bulgogi@bulgogi.com",
       "firstName": "Mclovin",
       "lastName": "Spongebob",
-      "phone": "5555",
-      "title": "some-title",
+      "phone": "123456789",
+      "title": "Mr.Chocolate",
       "organization": "org",
       "company": "segment",
-      "some-trait": "value",
-      "address": {
-        "city": "East Greenwich",
-        "state": "RI",
-        "postalCode": "02818",
-        "country": "USA"
+      "some-trait": "value"
+    },
+    "integrations": {
+      "Klaviyo": {
+        "listId": "baVTu8",
+        "confirmOptin": false
       }
     }
   },
   "output": {
+    "listId": "baVTu8",
     "peopleData": {
       "token": "hfWBjc",
       "properties": {
@@ -30,30 +28,24 @@
         "$email": "bulgogi@bulgogi.com",
         "$first_name": "Mclovin",
         "$last_name": "Spongebob",
-        "$phone_number": "5555",
-        "$title": "some-title",
+        "$phone_number": "123456789",
+        "$title": "Mr.Chocolate",
         "$organization": "org",
-        "$city": "East Greenwich",
-        "$country": "USA",
-        "$region": "RI",
-        "$zip": "02818",
-        "$timezone": "Europe/Amsterdam",
-        "address": {
-          "city": "East Greenwich",
-          "state": "RI",
-          "postalCode": "02818",
-          "country": "USA"
-        },
         "id": "01293721",
         "email": "bulgogi@bulgogi.com",
         "firstName": "Mclovin",
         "lastName": "Spongebob",
-        "phone": "5555",
-        "title": "some-title",
+        "phone": "123456789",
+        "title": "Mr.Chocolate",
         "some-trait": "value",
         "organization": "org",
         "company": "segment"
       }
+    },
+    "listData": {
+      "api_key": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
+      "email": "bulgogi@bulgogi.com",
+      "confirm_optin": false
     }
   }
 }

--- a/test/fixtures/identify-list.json
+++ b/test/fixtures/identify-list.json
@@ -1,0 +1,50 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "acp0m29",
+    "traits": {
+      "email": "newemail2@email.com",
+      "firstName": "Bender2",
+      "lastName": "Schmender",
+      "phone": "123456789",
+      "title": "Mr.Chocolate",
+      "organization": "org",
+      "company": "segment",
+      "some-trait": "value"
+    },
+    "integrations": {
+      "Klaviyo": {
+        "listId": "baVTu8"
+      }
+    }
+  },
+  "output": {
+    "listId": "baVTu8",
+    "peopleData": {
+      "token": "hfWBjc",
+      "properties": {
+        "$id": "acp0m29",
+        "$email": "newemail2@email.com",
+        "$first_name": "Bender2",
+        "$last_name": "Schmender",
+        "$phone_number": "123456789",
+        "$title": "Mr.Chocolate",
+        "$organization": "org",
+        "id": "acp0m29",
+        "email": "newemail2@email.com",
+        "firstName": "Bender2",
+        "lastName": "Schmender",
+        "phone": "123456789",
+        "title": "Mr.Chocolate",
+        "some-trait": "value",
+        "organization": "org",
+        "company": "segment"
+      }
+    },
+    "listData": {
+      "api_key": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
+      "email": "newemail2@email.com",
+      "confirm_optin": true
+    }
+  }
+}


### PR DESCRIPTION
**Purpose:** allow our `.identify()` calls to also take in optional data about [Klaviyo Lists](https://www.klaviyo.com/docs/api/lists#list-members). 

**Notable Changes:** This PR modifies our current `.identify()` call so that it makes up to two separate requests. 1st is to upsert the user profile. 2nd is to upsert them to a given listId. 

Also added some special reserved trait mapping that we missed earlier. It also looks like we're not stripping duplicate traits... which we should do in a future PR for sure. 

TODO:
Update docs
Update metadata since we need to collect two more options: privateKey to access the List API and whether they want the users to be opted in (email notification). 

@f2prateek @sperand-io Let me know what you think!
