### PR TITLE
change placed order to completed order for client side parity

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -75,9 +75,6 @@ exports.track = function(track){
 
 exports.completedOrder = function(track, settings){
   var products = track.products();
-  var categories = formatCategories(products);
-  var productNames = formatNames(products);
-  var items = formatItems(products);
   var payloads = {};
 
   payloads.order = {
@@ -93,9 +90,9 @@ exports.completedOrder = function(track, settings){
   payloads.order.properties = {
     $event_id: track.orderId(),
     $value: track.revenue(),
-    Categories: categories,
-    'Item Names': productNames,
-    'Items': items
+    Categories: formatCategories(products),
+    'Item Names': formatNames(products),
+    'Items': formatItems(products)
   };
 
   payloads.products = products.map(function(item){

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -82,7 +82,7 @@ exports.completedOrder = function(track, settings){
 
   payloads.order = {
     token: settings.apiKey,
-    event: 'Placed Order',
+    event: 'Completed Order',
     time: time(track.timestamp())
   };
 

--- a/test/fixtures/track-completed-order-urls.json
+++ b/test/fixtures/track-completed-order-urls.json
@@ -33,7 +33,7 @@
   "output": {
     "order": {
       "token" : "hfWBjc",
-      "event" : "Placed Order",
+      "event" : "Completed Order",
       "customer_properties" : {
         "$id": "user-id"
       },

--- a/test/fixtures/track-completed-order-urls.json
+++ b/test/fixtures/track-completed-order-urls.json
@@ -1,9 +1,9 @@
 {
   "input": {
-    "userId": "user-id",
+    "userId": "01293721",
     "type": "track",
     "event": "Completed Order",
-    "timestamp": "2014",
+    "timestamp": "2016",
     "properties": {
       "orderId": "order-id",
       "shipping": 5.00,
@@ -35,7 +35,7 @@
       "token" : "hfWBjc",
       "event" : "Completed Order",
       "customer_properties" : {
-        "$id": "user-id"
+        "$id": "01293721"
       },
       "properties" : {
         "$event_id" : "order-id",
@@ -63,14 +63,14 @@
           }
         ]
       },
-      "time" : 1388534400
+      "time" : 1451606400
     },
     "products": [
       {
         "token": "hfWBjc",
         "event": "Ordered Product",
-        "time": 1388534400,
-        "customer_properties": { "$id": "user-id" },
+        "time": 1451606400,
+        "customer_properties": { "$id": "01293721" },
         "properties": {
           "$event_id": 123,
           "$value": 20,
@@ -84,8 +84,8 @@
       {
         "token": "hfWBjc",
         "event": "Ordered Product",
-        "time": 1388534400,
-        "customer_properties": { "$id": "user-id" },
+        "time": 1451606400,
+        "customer_properties": { "$id": "01293721" },
         "properties": {
           "$event_id": 455,
           "$value": 30,

--- a/test/fixtures/track-completed-order.json
+++ b/test/fixtures/track-completed-order.json
@@ -1,11 +1,11 @@
 {
   "input": {
-    "userId": "user-id",
+    "userId": "01293721",
     "type": "track",
     "event": "Completed Order",
     "timestamp": "2014",
     "properties": {
-      "orderId": "order-id",
+      "orderId": "02914701298",
       "shipping": 5.00,
       "total": 65.00,
       "revenue": 50.00,
@@ -33,10 +33,10 @@
       "token" : "hfWBjc",
       "event" : "Completed Order",
       "customer_properties" : {
-        "$id": "user-id"
+        "$id": "01293721"
       },
       "properties" : {
-        "$event_id" : "order-id",
+        "$event_id" : "02914701298",
         "$value" : 50.00,
         "Categories" : ["gaming", "console"],
         "Item Names" : ["sony pulse", "sony playstation 4"],
@@ -66,7 +66,7 @@
         "token": "hfWBjc",
         "event": "Ordered Product",
         "time": 1388534400,
-        "customer_properties": { "$id": "user-id" },
+        "customer_properties": { "$id": "01293721" },
         "properties": {
           "$event_id": 123,
           "$value": 20,
@@ -79,7 +79,7 @@
         "token": "hfWBjc",
         "event": "Ordered Product",
         "time": 1388534400,
-        "customer_properties": { "$id": "user-id" },
+        "customer_properties": { "$id": "01293721" },
         "properties": {
           "$event_id": 455,
           "$value": 30,

--- a/test/fixtures/track-completed-order.json
+++ b/test/fixtures/track-completed-order.json
@@ -31,7 +31,7 @@
   "output": {
     "order": {
       "token" : "hfWBjc",
-      "event" : "Placed Order",
+      "event" : "Completed Order",
       "customer_properties" : {
         "$id": "user-id"
       },

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,8 @@ var facade = require('segmentio-facade');
 var should = require('should');
 var assert = require('assert');
 var Klaviyo = require('..');
+var time = require('unix-time');
+var uid = require('uid');
 
 describe('Klaviyo', function () {
   var settings;
@@ -99,8 +101,15 @@ describe('Klaviyo', function () {
     });
 
     describe('.completedOrder()', function(){
-      it('should successfully send the Placed Order event', function(done){
+      it('should successfully send the Completed Order event', function(done){
         var json = test.fixture('track-completed-order');
+        var newOrderId = uid();
+        var newDate = new Date;
+        json.input.timestamp = newDate;
+        json.output.order.time = time(newDate);
+        json.input.properties.orderId = newOrderId;
+        json.output.order.properties.$event_id = newOrderId;
+
 
         test
           .set(settings)
@@ -111,20 +120,22 @@ describe('Klaviyo', function () {
           .end(done);
       });
 
-      it('should sucessfully send the Ordered Product event', function(done){
-        var json = test.fixture('track-completed-order');
-
-        test
-          .set(settings)
-          .track(json.input)
-          .request(1)
-          .query('data', json.output.products[0], decode)
-          .expects(200)
-          .end(done);
-      });
-
       it('should sucessfully send Order Product event for each product', function(done){
-        var json = test.fixture('track-completed-order');
+        var json = test.fixture('track-completed-order-urls');
+        var newDate = new Date;
+        var newOrderId = uid();
+        var newProductIdOne = uid();
+        var newProductIdTwo = uid();
+        json.input.timestamp = newDate;
+        json.output.order.time = time(newDate);
+        json.output.products[0].time = time(newDate);
+        json.output.products[1].time = time(newDate);
+        json.input.properties.orderId = newOrderId;
+        json.output.order.properties.$event_id = newOrderId;
+        json.input.properties.products[0].id = newProductIdOne;
+        json.input.properties.products[1].id = newProductIdTwo;
+        json.output.products[0].properties.$event_id = newProductIdOne;
+        json.output.products[1].properties.$event_id = newProductIdTwo;
 
         test
           .set(settings)


### PR DESCRIPTION
Do not merge yet!

This PR is in preparation so that we can achieve parity between our server side integration and client side integration. We are able to change this easily from Klaviyo's API point of view since the event name "placed order" is not semantic or have any feature dependency inside Klaviyo's reporting.

also realized that our test's outdated `timestamps` and static `orderId` and `product[x].id` are preventing you from seeing the test data inside Klaviyo UI. Just did a quick monkey patch on the test file to fix this. Will refractor later since it's super ugly right now.

@sperand-io @f2prateek 
