### PR TITLE
add ui default listId support

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -20,6 +20,7 @@ var reject = require('reject');
 
 exports.identify = function(identify){
   var opts = identify.options(this.name);
+  var listId = opts.listId || this.settings.listId;
   var msg = {
     peopleData: {
       token: this.settings.apiKey,
@@ -28,8 +29,8 @@ exports.identify = function(identify){
   };
 
   // email, listId, and api_key all required
-  if (opts.listId && identify.email() && this.settings.privateKey) {
-    msg.listId = opts.listId;
+  if (listId && identify.email() && this.settings.privateKey) {
+    msg.listId = listId;
     msg.listData = {
       email: identify.email(),
       api_key: this.settings.privateKey,

--- a/test/fixtures/identify-list.json
+++ b/test/fixtures/identify-list.json
@@ -11,11 +11,6 @@
       "organization": "org",
       "company": "segment",
       "some-trait": "value"
-    },
-    "integrations": {
-      "Klaviyo": {
-        "listId": "baVTu8"
-      }
     }
   },
   "output": {

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,8 @@ describe('Klaviyo', function () {
     settings = { 
       apiKey: 'hfWBjc',
       privateKey: 'pk_95773fc9a18f5728da58471d70a4dcbcdf',
-      confirmOptin: true 
+      confirmOptin: true,
+      listId: 'baVTu8' 
     };
     klaviyo = new Klaviyo(settings);
     test = Test(klaviyo, __dirname);
@@ -43,10 +44,12 @@ describe('Klaviyo', function () {
   describe('mapper', function(){
     describe('identify', function(){
       it('should map basic identify', function(){
+        delete settings.listId;
         test.maps('identify-basic', settings);
       });
 
       it('should fallback to anonymousId', function(){
+        delete settings.listId;
         test.maps('identify-anonymous-id', settings);
       });
 
@@ -181,8 +184,9 @@ describe('Klaviyo', function () {
         .end(done);
     });
 
-    it('should override confirmOptin setting if provided', function(done){
+    it('should override confirmOptin and listId setting if manually provided', function(done){
       var json = test.fixture('identify-list-override');
+      delete settings.listId;
       json.output.peopleData.token = settings.apiKey;
       json.output.listData.api_key = settings.privateKey;
 
@@ -231,7 +235,7 @@ describe('Klaviyo', function () {
 
     it('should not try to hit list api if listId is not provided', function(done){
       var json = test.fixture('identify-list');
-      delete json.input.integrations.Klaviyo.listId;
+      delete settings.listId;
 
       test
         .set(settings)


### PR DESCRIPTION
This will allow you to add a default listId in your Klaviyo setting that we can fall back on as a default when adding people to lists.

This works in the same way as our Mailchimp integration.

@sperand-io @f2prateek 
