### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ Klaviyo.prototype.identify = function(msg, fn) {
 Klaviyo.prototype.track = request('/track');
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * https://www.klaviyo.com/docs
  *
@@ -80,8 +80,8 @@ Klaviyo.prototype.track = request('/track');
  * @api private
  */
 
-Klaviyo.prototype.completedOrder = function(track, fn) {
-  var payload = mapper.completedOrder(track, this.settings);
+Klaviyo.prototype.orderCompleted = function(track, fn) {
+  var payload = mapper.orderCompleted(track, this.settings);
   var batch = new Batch();
   var self = this;
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -66,7 +66,7 @@ exports.track = function(track){
 };
 
 /**
- * Map Completed Order
+ * Map Order Completed
  *
  * Docs: http://learn.klaviyo.com/12887-Ecommerce:-Other-Integrations/product-activity-integrating-a-custom-ecommerce-cart-or-platform
  *
@@ -75,7 +75,7 @@ exports.track = function(track){
  * @api private
  */
 
-exports.completedOrder = function(track, settings){
+exports.orderCompleted = function(track, settings){
   var products = track.products();
   var categories = formatCategories(products);
   var productNames = formatNames(products);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "extend": "^2.0.0",
     "obj-case": "^0.2.0",
     "reject": "0.0.1",
-    "segmentio-integration": "^3.2.0",
+    "segmentio-integration": "^4.0.0",
     "unix-time": "^1.0.1"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "mocha": "2.x",
     "ms": "0.x",
     "segmentio-facade": "2.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-integration-tester": "2.x",
     "should": "^4.3.0",
     "uid": "0.0.2",
     "unix-time": "1.x"

--- a/test/fixtures/track-order-completed-custom.json
+++ b/test/fixtures/track-order-completed-custom.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "hamsolo",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "timestamp": "2016",
     "properties": {
       "customProp": "boo",

--- a/test/fixtures/track-order-completed-urls.json
+++ b/test/fixtures/track-order-completed-urls.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "timestamp": "2016",
     "properties": {
       "orderId": "order-id",

--- a/test/fixtures/track-order-completed.json
+++ b/test/fixtures/track-order-completed.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "timestamp": "2016",
     "properties": {
       "orderId": "order-id",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -52,7 +52,7 @@ exports.transaction = function(options){
     userId: firstId,
     channel: 'server',
     timestamp: new Date,
-    event: 'Completed Order',
+    event: 'Order Completed',
     properties: {
       orderId: 't-39a224df',
       total: 99.99,
@@ -91,37 +91,37 @@ exports.transaction = function(options){
 exports.track = function (options) {
   options = options || {};
   return new facade.Track(merge({
-    userId     : firstId,
-    event      : 'Baked a cake',
-    properties : {
-      layers  : ['chocolate', 'strawberry', 'fudge'],
-      revenue : 19.95,
-      numLayers : 10,
-      fat : 0.02,
-      bacon : '1',
-      date : (new Date()).toISOString(),
-      address : {
-        state : 'CA',
-        zip  : 94107,
-        city : 'San Francisco'
+    userId: firstId,
+    event: 'Baked a cake',
+    properties: {
+      layers: ['chocolate', 'strawberry', 'fudge'],
+      revenue: 19.95,
+      numLayers: 10,
+      fat: 0.02,
+      bacon: '1',
+      date: (new Date()).toISOString(),
+      address: {
+        state: 'CA',
+        zip: 94107,
+        city: 'San Francisco'
       }
     },
-    channel    : 'server',
-    timestamp  : new Date(),
-    options : {
-      traits : {
-        email   : options.email || email,
-        age     : 23,
-        created : new Date(),
-        bad     : null,
-        alsoBad : undefined,
-        address : {
-          state : 'CA',
-          zip  : 94107,
-          city : 'San Francisco'
+    channel: 'server',
+    timestamp: new Date(),
+    options: {
+      traits: {
+        email: options.email || email,
+        age: 23,
+        created: new Date(),
+        bad: null,
+        alsoBad: undefined,
+        address: {
+          state: 'CA',
+          zip: 94107,
+          city: 'San Francisco'
         }
       },
-      ip : '4.184.68.0',
+      ip: '4.184.68.0',
       userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
     }
   }, options));
@@ -137,9 +137,9 @@ exports.track = function (options) {
 
 exports.track.bare = function (options) {
   return new facade.Track(merge({
-    userId  : 'aaa',
-    event   : 'Bear tracks',
-    channel : 'server'
+    userId: 'aaa',
+    event: 'Bear tracks',
+    channel: 'server'
   }, options || {}));
 };
 
@@ -153,33 +153,33 @@ exports.track.bare = function (options) {
 exports.identify = function (options) {
   options = options || {};
   return new facade.Identify(merge({
-    userId : firstId,
-    traits : {
-      fat         : 0.02,
-      firstName   : 'John',
-      'Last Name' : 'Doe',
-      email       : options.email || email,
-      company     : 'Segment.io',
-      city        : 'San Francisco',
-      state       : 'CA',
-      phone       : '5555555555',
-      websites    : [
+    userId: firstId,
+    traits: {
+      fat: 0.02,
+      firstName: 'John',
+      'Last Name': 'Doe',
+      email: options.email || email,
+      company: 'Segment.io',
+      city: 'San Francisco',
+      state: 'CA',
+      phone: '5555555555',
+      websites: [
         'http://calv.info',
         'http://ianstormtaylor.com',
         'http://ivolo.me',
         'http://rein.pk'
       ],
-      bad     : null,
-      alsoBad : undefined,
-      met : (new Date()).toISOString(),
-      created : new Date('1/12/2013'),
+      bad: null,
+      alsoBad: undefined,
+      met: (new Date()).toISOString(),
+      created: new Date('1/12/2013'),
       userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
     },
-    context : {
-      ip : '12.212.12.49'
+    context: {
+      ip: '12.212.12.49'
     },
-    timestamp : new Date(),
-    channel : 'server'
+    timestamp: new Date(),
+    channel: 'server'
   }, options));
 };
 
@@ -266,9 +266,9 @@ exports.group = function(options){
 
 exports.alias = function (options) {
   return new facade.Alias(merge({
-    from      : firstId,
-    to        : secondId,
-    channel   : 'server',
-    timestamp : new Date()
+    from: firstId,
+    to: secondId,
+    channel: 'server',
+    timestamp: new Date()
   }, options || {}));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -75,16 +75,16 @@ describe('Klaviyo', function () {
         test.maps('track-eventId', settings);
       });
 
-      it('should map completed order', function() {
-        test.maps('track-completed-order', settings);
+      it('should map order completed', function() {
+        test.maps('track-order-completed', settings);
       });
 
-      it('should map completed order with urls', function() {
-        test.maps('track-completed-order-urls', settings);
+      it('should map order completed with urls', function() {
+        test.maps('track-order-completed-urls', settings);
       });
 
-      it('should map completed order with custom props', function() {
-        test.maps('track-completed-order-custom', settings);
+      it('should map order completed with custom props', function() {
+        test.maps('track-order-completed-custom', settings);
       });
     });
   });
@@ -107,7 +107,7 @@ describe('Klaviyo', function () {
 
     describe('.completedOrder()', function(){
       it('should successfully send the Placed Order event', function(done){
-        var json = test.fixture('track-completed-order');
+        var json = test.fixture('track-order-completed');
 
         test
           .set(settings)
@@ -119,7 +119,7 @@ describe('Klaviyo', function () {
       });
 
       it('should sucessfully send the Ordered Product event', function(done){
-        var json = test.fixture('track-completed-order');
+        var json = test.fixture('track-order-completed');
 
         test
           .set(settings)
@@ -131,7 +131,7 @@ describe('Klaviyo', function () {
       });
 
       it('should sucessfully send Order Product event for each product', function(done){
-        var json = test.fixture('track-completed-order');
+        var json = test.fixture('track-order-completed');
 
         test
           .set(settings)
@@ -150,8 +150,8 @@ describe('Klaviyo', function () {
           .end(done);
       });
 
-      it('should let custom properties pass for completed order', function(done){
-        var json = test.fixture('track-completed-order-custom');
+      it('should let custom properties pass for order completed', function(done){
+        var json = test.fixture('track-order-completed-custom');
 
         test
           .set(settings)


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.
