### PR TITLE
ensure unique  for ordered product events

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,10 @@
 
+
+1.1.1 / 2016-10-18
+==================
+
+  * Ensure unique $event_id for auto-generated  ordered product events
+
 1.1.0 / 2016-09-06
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -77,6 +77,7 @@ exports.track = function(track){
 
 exports.orderCompleted = function(track, settings){
   var products = track.products();
+  var orderId = track.orderId();
   var categories = formatCategories(products);
   var productNames = formatNames(products);
   var items = formatItems(products);
@@ -93,7 +94,7 @@ exports.orderCompleted = function(track, settings){
   };
 
   payloads.order.properties = {
-    $event_id: track.orderId(),
+    $event_id: orderId,
     $value: track.revenue(),
     Categories: categories,
     'Item Names': productNames,
@@ -150,13 +151,16 @@ exports.orderCompleted = function(track, settings){
     };
 
     productPayload.properties = {
-      $event_id: product.productId() || product.id() || track.orderId() + '_' + product.sku(),
       $value: product.price(),
       Name: product.name(),
       Quantity: product.quantity(),
       "Product Categories": [product.category()],
       SKU: product.sku()
     };
+
+    // ensure unique $event_id is associated with each Ordered Product event by combining Order Completed order_id and product's productId or SKU
+    var identifier = product.productId() || product.id() || product.sku();
+    productPayload.properties.$event_id = orderId + '_' + identifier;
 
     productPayload.properties = extend(productPayload.properties, itemCustomProps);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-klaviyo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Klaviyo server-side integration",
   "author": "Segment <friends@segment.com>",

--- a/test/fixtures/track-order-completed-custom.json
+++ b/test/fixtures/track-order-completed-custom.json
@@ -85,7 +85,7 @@
         "time": 1451606400,
         "customer_properties": { "$id": "hamsolo" },
         "properties": {
-          "$event_id": 123,
+          "$event_id": "order-id22_123",
           "$value": 20,
           "Name": "sony pulse",
           "Product Categories": ["gaming"],
@@ -103,7 +103,7 @@
         "time": 1451606400,
         "customer_properties": { "$id": "hamsolo" },
         "properties": {
-          "$event_id": 455,
+          "$event_id": "order-id22_455",
           "$value": 30,
           "Name": "sony playstation 4",
           "Product Categories": ["console"],

--- a/test/fixtures/track-order-completed-urls.json
+++ b/test/fixtures/track-order-completed-urls.json
@@ -77,7 +77,7 @@
         "time": 1451606400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
-          "$event_id": 123,
+          "$event_id": "order-id_123",
           "$value": 20,
           "Name": "sony pulse",
           "Product Categories": ["gaming"],
@@ -93,7 +93,7 @@
         "time": 1451606400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
-          "$event_id": 455,
+          "$event_id": "order-id_455",
           "$value": 30,
           "Name": "sony playstation 4",
           "Product Categories": ["console"],

--- a/test/fixtures/track-order-completed.json
+++ b/test/fixtures/track-order-completed.json
@@ -73,7 +73,7 @@
         "time": 1451606400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
-          "$event_id": 123,
+          "$event_id": "order-id_123",
           "$value": 20,
           "Name": "sony pulse",
           "Product Categories": ["gaming"],
@@ -87,7 +87,7 @@
         "time": 1451606400,
         "customer_properties": { "$id": "user-id" },
         "properties": {
-          "$event_id": 455,
+          "$event_id": "order-id_455",
           "$value": 30,
           "Name": "sony playstation 4",
           "Product Categories": ["console"],


### PR DESCRIPTION
This PR ensures that each "Ordered Product" event contained a unique `$event_id`. Segment currently sends `productId` as `$event_id` for "Ordered Product" events. Klaviyo requires that `$event_ids` are unique - productIds are not unique, so subsequent events containing existing $event_ids are rejected by Klaviyo.

The issue is affecting customers and is described in this JIRA ticket: https://segment.atlassian.net/browse/BUGS-630

This update should not be a breaking change. We're simply updating the format of $event_id for future events to ensure that this id is always unique for new events. Klaviyo outlines this requirement in their docs here: https://www.klaviyo.com/docs

PR for docs update: https://github.com/segmentio/site-docs/pull/1985
