### PR TITLE
[DNM — WIP] Updates to Identify Behavior (To Prevent Duplicates and Redundant Data)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,12 +47,23 @@ Klaviyo.prototype.identify = function(msg, fn) {
       if (!msg.listData) return fn(null, res);
 
       // https://www.klaviyo.com/docs/api/lists
-      // Add this person to a List
+      // Check if this person is in target list already
       self
-        .post('/v1/list/' + msg.listId + '/members') // upsertion endpoint
-        .type('form')
-        .send(msg.listData)
-        .end(fn);
+        .get('/v1/list/' + msg.listId + '/members') // endpoint
+        .query({ api_key: msg.listData.api_key, email: msg.listData.email })
+        .end(function(err, res) {
+          if (err) return fn(err);
+          if (res.body.data.length === 0) {
+            // user not in list. add.
+            return self
+              .post('/v1/list/' + msg.listId + '/members') // upsertion endpoint
+              .type('form')
+              .send(msg.listData)
+              .end(fn);
+          }
+          // if no error, user already exists, bail
+          return fn(err);
+        });
     });
 };
 
@@ -67,7 +78,17 @@ Klaviyo.prototype.identify = function(msg, fn) {
  * @api private
  */
 
-Klaviyo.prototype.track = request('/track');
+Klaviyo.prototype.track = function(track, fn) {
+  var self = this;
+  this
+    .get('/track')
+    .query({ data: new Buffer(JSON.stringify(track)).toString('base64') })
+    .end(this.handle(function(err, res){
+      if (err) return fn(err);
+      if (res.text != '1') err = self.error('bad response');
+      return fn(err, res);
+    }));
+}
 
 /**
  * Order Completed.
@@ -105,38 +126,3 @@ Klaviyo.prototype.orderCompleted = function(track, fn) {
       batch.end(fn);
     });
 };
-
-/**
- * Check klaviyo's request.
- *
- * @param {Function} fn
- * @api private
- */
-
-Klaviyo.prototype.check = function(fn){
-  var self = this;
-  return this.handle(function(err, res){
-    if (err) return fn(err);
-    if (res.text != '1') err = self.error('bad response');
-    return fn(err, res);
-  });
-};
-
-/**
- * Create request for `path`.
- *
- * @param {String} path
- * @return {Function}
- * @api private
- */
-
-function request(path){
-  return function(payload, fn){
-    payload = JSON.stringify(payload);
-    payload = new Buffer(payload).toString('base64');
-    return this
-      .get(path)
-      .query({ data: payload })
-      .end(this.check(fn));
-  };
-}

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -21,10 +21,13 @@ var remove = require('obj-case').del;
 exports.identify = function(identify) {
   var opts = identify.options(this.name);
   var listId = opts.listId || this.settings.listId;
+  var userId = identify.userId();
+  var anonymousId = identify.anonymousId();
+
   var msg = {
     peopleData: {
       token: this.settings.apiKey,
-      properties: traits(identify)
+      properties: extend(traits(identify), { $anonymous: anonymousId })
     }
   };
 
@@ -34,11 +37,12 @@ exports.identify = function(identify) {
     msg.listData = {
       api_key: this.settings.privateKey,
       email: identify.email(),
-      properties: {
-        $id: identify.userId()
-      },
+      properties: {},
       confirm_optin: opts.confirmOptin != undefined ? opts.confirmOptin : this.settings.confirmOptin // default setting is true, can be overriden per event via options
     };
+
+    if (userId) msg.listData.properties.$id =  userId;
+    if (anonymousId) msg.listData.properties.$anonymous = anonymousId;
   }
 
   return msg;
@@ -298,20 +302,24 @@ function properties(track) {
  */
 
 function traits(identify) {
-  var traits = identify.traits();
-  // why are we extending and not removing duplicate traits here?
-  return reject(extend(traits, {
-    $id: identify.userId() || identify.sessionId(),
-    $email: identify.email(),
-    $first_name: identify.firstName(),
-    $last_name: identify.lastName(),
-    $phone_number: identify.phone(),
-    $title: identify.proxy('traits.title') || identify.position(),
-    $organization: identify.proxy('traits.organization'),
-    $city: identify.city(),
-    $region: identify.region() || identify.state(),
-    $country: identify.country(),
-    $timezone: identify.timezone(),
-    $zip: identify.zip()
+  var ret =  reject(identify.traits({
+    id: '$id',
+    email: '$email',
+    firstName: '$first_name',
+    lastName: '$last_name',
+    phone: '$phone_number',
+    position: '$title',
+    title: '$title',
+    organization: '$organization',
+    company: '$organization',
+    city: '$city',
+    state: '$region',
+    region: '$region',
+    country: '$country',
+    timezone: '$timezone',
+    zip: '$zip'
   }));
+
+  delete ret.id;
+  return ret;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "merge-util": "^0.1.0",
     "mocha": "2.x",
     "ms": "0.x",
+    "randomstring": "^1.1.5",
     "segmentio-facade": "^3.x",
     "segmentio-integration-tester": "^2.x",
     "should": "^4.3.0",

--- a/test/fixtures/identify-anonymous-id.json
+++ b/test/fixtures/identify-anonymous-id.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "identify",
-    "anonymousId": "user-id",
+    "anonymousId": "anon-id",
     "traits": {
       "email": "johndoe@segment.io",
       "firstName": "John",
@@ -17,21 +17,14 @@
     "peopleData": {
       "token": "hfWBjc",
       "properties": {
-        "$id": "user-id",
         "$email": "johndoe@segment.io",
         "$first_name": "John",
         "$last_name": "Doe",
         "$phone_number": "5555",
         "$title": "some-title",
-        "$organization": "org",
-        "email": "johndoe@segment.io",
-        "firstName": "John",
-        "lastName": "Doe",
-        "phone": "5555",
-        "title": "some-title",
-        "some-trait": "value",
-        "organization": "org",
-        "company": "segment"
+        "$organization": "segment",
+        "$anonymous": "anon-id",
+        "some-trait": "value"
       }
     }
   }

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -32,7 +32,7 @@
         "$last_name": "turkey",
         "$phone_number": "5555",
         "$title": "some-title",
-        "$organization": "org",
+        "$organization": "segment",
         "$city": "East Greenwich",
         "$country": "USA",
         "$region": "RI",
@@ -44,15 +44,7 @@
           "postalCode": "02818",
           "country": "USA"
         },
-        "id": "hamsolo",
-        "email": "hamsolo@gmail.com",
-        "firstName": "ham",
-        "lastName": "turkey",
-        "phone": "5555",
-        "title": "some-title",
-        "some-trait": "value",
-        "organization": "org",
-        "company": "segment"
+        "some-trait": "value"
       }
     }
   }

--- a/test/fixtures/identify-list-override.json
+++ b/test/fixtures/identify-list-override.json
@@ -30,16 +30,8 @@
         "$last_name": "Spongebob",
         "$phone_number": "123456789",
         "$title": "Mr.Chocolate",
-        "$organization": "org",
-        "id": "01293721",
-        "email": "bulgogi@bulgogi.com",
-        "firstName": "Mclovin",
-        "lastName": "Spongebob",
-        "phone": "123456789",
-        "title": "Mr.Chocolate",
-        "some-trait": "value",
-        "organization": "org",
-        "company": "segment"
+        "$organization": "segment",
+        "some-trait": "value"
       }
     },
     "listData": {

--- a/test/fixtures/identify-list.json
+++ b/test/fixtures/identify-list.json
@@ -24,16 +24,8 @@
         "$last_name": "Schmender",
         "$phone_number": "123456789",
         "$title": "Mr.Chocolate",
-        "$organization": "org",
-        "id": "acp0m29",
-        "email": "newemail2@email.com",
-        "firstName": "Bender2",
-        "lastName": "Schmender",
-        "phone": "123456789",
-        "title": "Mr.Chocolate",
-        "some-trait": "value",
-        "organization": "org",
-        "company": "segment"
+        "$organization": "segment",
+        "some-trait": "value"
       }
     },
     "listData": {


### PR DESCRIPTION
A few proposed updates to Klaviyo for our teams' mutual consideration based directly on or orthogonally to our ongoing discussions. 

- [x] do not send redundant traits if we send the "special-cased" sort
- [x] check list for user membership by email prior to trying to add them to it (is this helpful?)
- [x] do not fall back `$id` to segment anonymousId; rather, always send anonymousId as `$anonymous`
- [x] map `traits.company` to `$organization`
- [x] send `properties.$id` in `add to list` request

... i propose considering each change in isolation, and then deciding how we want to move forward with them (open to eg. separate PRs, putting any breaking changes (all except list membership check are, i believe) on a new version and making that the new default, or just conducting comms with existing customers and transitioning everyone to the new behavior(s) we all settle on if that's what the teams prefer)

---

Now that I've gotten steeped in the integration, one other potential idea for avoiding duplicates:

- [ ] add to list *first* w/ email & properties.$id and properties.$anonymous *prior* to call to `/identify` endpoint? (I wonder if this would be a definite way to solve duplicate user insertions given that the sync APIs are hit first.

eg. proposed flow:

```
if listId
  email in list? (check via sync api)
    if no: 
      add (sync)
      identify
    else 
      identify
else
  identify
```
