### PR TITLE
lock on adding to list to avoid dupes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,32 +29,61 @@ var Klaviyo = module.exports = integration('Klaviyo')
  * @api public
  */
 
-Klaviyo.prototype.identify = function(msg, fn) {
+Klaviyo.prototype.identify = function(mapped, fn) {
   var self = this;
 
+  if (!mapped.listId) {
+    return this._identify(mapped.peopleData, fn)
+  }
+
+  var key = [this.settings.apiKey, mapped.peopleData.$id].join(':');
+  this.lock(key, function() {
+    self._addToList(mapped.listId, mapped.listData, function(err, res) {
+      self.unlock(key, function() {
+        if (err) return fn(err);
+        self._identify(mapped.peopleData, fn)
+      });
+    });
+  });
+};
+
+/**
+ * Add to List.
+ *
+ * https://www.klaviyo.com/docs
+ *
+ * @param {Object} listData
+ * @param {Object} settings
+ * @param {Function} fn
+ * @api public
+ */
+
+Klaviyo.prototype._addToList = function(id, data, fn) {
+  this
+    .post('/v1/list/' + id + '/members') // upsertion endpoint
+    .type('form')
+    .send(data)
+    .end(fn);
+};
+
+/**
+ * /identify.
+ *
+ * https://www.klaviyo.com/docs
+ *
+ * @param {Object} peopleData
+ * @param {Object} settings
+ * @param {Function} fn
+ * @api public
+ */
+
+Klaviyo.prototype._identify = function(data, fn) {
+  var self = this;
   this
     .get('/identify')
-    .query({ data: new Buffer(JSON.stringify(msg.peopleData)).toString('base64') })
-    .end(function(err, res){
-      if (err) return fn(err);
-
-      // 1 = success 0 = failure
-      if (res.text != '1') {
-        err = self.error('bad response');
-        return fn(err, res);
-      }
-
-      if (!msg.listData) return fn(null, res);
-
-      // https://www.klaviyo.com/docs/api/lists
-      // Add this person to a List
-      self
-        .post('/v1/list/' + msg.listId + '/members') // upsertion endpoint
-        .type('form')
-        .send(msg.listData)
-        .end(fn);
-    });
-};
+    .query({ data: encode(data) })
+    .end(this.check(fn));
+}
 
 /**
  * Track.
@@ -67,7 +96,12 @@ Klaviyo.prototype.identify = function(msg, fn) {
  * @api private
  */
 
-Klaviyo.prototype.track = request('/track');
+Klaviyo.prototype.track = function(payload, fn) {
+  return this
+    .get('/track')
+    .query({ data: encode(payload) })
+    .end(this.check(fn));
+};
 
 /**
  * Order Completed.
@@ -89,7 +123,7 @@ Klaviyo.prototype.orderCompleted = function(track, fn) {
 
   this
     .get('/track')
-    .query({ data: new Buffer(JSON.stringify(payload.order)).toString('base64') })
+    .query({ data: encode(payload.order) })
     .end(function(err){
       if (err) return fn(err);
 
@@ -97,7 +131,7 @@ Klaviyo.prototype.orderCompleted = function(track, fn) {
         batch.push(function(done){
           self
             .get('/track')
-            .query({ data: new Buffer(JSON.stringify(product)).toString('base64') })
+            .query({ data: encode(product) })
             .end(self.handle(done));
         });
       })
@@ -123,20 +157,12 @@ Klaviyo.prototype.check = function(fn){
 };
 
 /**
- * Create request for `path`.
+ * Encode.
  *
- * @param {String} path
- * @return {Function}
- * @api private
+ * @param {Object} data
+ * @return {String} data
  */
 
-function request(path){
-  return function(payload, fn){
-    payload = JSON.stringify(payload);
-    payload = new Buffer(payload).toString('base64');
-    return this
-      .get(path)
-      .query({ data: payload })
-      .end(this.check(fn));
-  };
+function encode(data) {
+  return new Buffer(JSON.stringify(data)).toString('base64');
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "unix-time": "^1.0.1"
   },
   "devDependencies": {
+    "batch": "^0.5.3",
     "istanbul": "0.x",
     "jscs": "1.x",
     "merge-util": "^0.1.0",
     "mocha": "2.x",
     "ms": "0.x",
+    "redis": "^2.6.3",
     "segmentio-facade": "^3.x",
     "segmentio-integration-tester": "^2.x",
     "should": "^4.3.0",


### PR DESCRIPTION
this is @sperand-io on wesley's computer. upon further testing with wes, we were unable to avoid creating dupes by passing properties.$id in our add_to_list calls.

However, when we reversed the order and waited to identify (which is async) until after hearing back from the sync add_to_list endpoint, no more dupes were created. 

One other change involved here is the stripping of redundant traits. Should we include that here?

The remaining question is how to handle falling back to anonymousId (and whether we should at all).

Options:

- remove fallback outright
- make it an option
- cut 2 versions and put new users on version with no anonId fallback.



