### PR TITLE
Send Email only EPD-2369

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,14 @@
 
+1.4.0 / 2017-04-05
+==================
+
+  * Add new option to only send $email and not $id for dupe reasons with Klaviyo's API
+
 1.3.0 / 2017-01-31
 ==================
 
   * Standardize integration (linting, Docker configuration, circle.yml, upgrade
 segmentio-integration version, upgrade integration-worker version, etc.)
-
 
 1.2.1 / 2016-12-08
 ==================

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -28,7 +28,7 @@ exports.identify = function(identify) {
 
   return {
     token: this.settings.apiKey,
-    properties: traits(identify),
+    properties: traits(identify, this.settings),
     email: identify.email(),
     apiKey: this.settings.privateKey,
     confirmOptIn: confirmOptIn,
@@ -47,16 +47,19 @@ exports.identify = function(identify) {
  */
 
 exports.track = function(track) {
-  return {
+  var ret = {
     token: this.settings.apiKey,
     event: track.event(),
     properties: properties(track),
     time: time(track.timestamp()),
     customer_properties: {
-      $id: track.userId() || track.sessionId(),
       $email: track.email()
     }
   };
+
+  if (!this.settings.enforceEmail) ret.customer_properties.$id = track.userId() || track.anonymousId()
+
+  return ret;
 };
 
 /**
@@ -83,9 +86,7 @@ exports.orderCompleted = function(track, settings) {
     time: time(track.timestamp())
   };
 
-  payloads.order.customer_properties = {
-    $id: track.userId() || track.sessionId()
-  };
+  if (!settings.enforceEmail) payloads.order.customer_properties = { $id: track.userId() || track.anonymousId() }
 
   payloads.order.properties = {
     $event_id: orderId,
@@ -140,9 +141,7 @@ exports.orderCompleted = function(track, settings) {
     // filter standard item props so we can merge custom props later
     var itemCustomProps = filter(product, itemWhitelist);
 
-    productPayload.customer_properties = {
-      $id: track.userId() || track.sessionId()
-    };
+    if (!settings.enforceEmail) productPayload.customer_properties = { $id: track.userId() || track.anonymousId() }
 
     productPayload.properties = {
       $value: product.price(),
@@ -289,11 +288,10 @@ function properties(track) {
  * @api private
  */
 
-function traits(identify) {
+function traits(identify, settings) {
   var traits = identify.traits();
   // why are we extending and not removing duplicate traits here?
-  return reject(extend(traits, {
-    $id: identify.userId() || identify.sessionId(),
+  var ret = extend(traits, {
     $email: identify.email(),
     $first_name: identify.firstName(),
     $last_name: identify.lastName(),
@@ -305,5 +303,9 @@ function traits(identify) {
     $country: identify.country(),
     $timezone: identify.timezone(),
     $zip: identify.zip()
-  }));
+  });
+
+  if (!settings.enforceEmail) ret.$id = identify.userId() || identify.anonymousId()
+
+  return reject(ret);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-klaviyo",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Klaviyo server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/identify-email-only.json
+++ b/test/fixtures/identify-email-only.json
@@ -1,0 +1,59 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "hamsolo",
+    "context": {
+      "timezone": "Europe/Amsterdam"
+    },
+    "traits": {
+      "email": "hamsolo@gmail.com",
+      "firstName": "ham",
+      "lastName": "turkey",
+      "phone": "5555",
+      "title": "some-title",
+      "organization": "org",
+      "company": "segment",
+      "some-trait": "value",
+      "address": {
+        "city": "East Greenwich",
+        "state": "RI",
+        "postalCode": "02818",
+        "country": "USA"
+      }
+    }
+  },
+  "output": {
+    "apiKey": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
+    "confirmOptIn": true,
+    "email": "hamsolo@gmail.com",
+    "token": "hfWBjc",
+    "properties": {
+      "$email": "hamsolo@gmail.com",
+      "$first_name": "ham",
+      "$last_name": "turkey",
+      "$phone_number": "5555",
+      "$title": "some-title",
+      "$organization": "org",
+      "$city": "East Greenwich",
+      "$country": "USA",
+      "$region": "RI",
+      "$zip": "02818",
+      "$timezone": "Europe/Amsterdam",
+      "address": {
+        "city": "East Greenwich",
+        "state": "RI",
+        "postalCode": "02818",
+        "country": "USA"
+      },
+      "id": "hamsolo",
+      "email": "hamsolo@gmail.com",
+      "firstName": "ham",
+      "lastName": "turkey",
+      "phone": "5555",
+      "title": "some-title",
+      "some-trait": "value",
+      "organization": "org",
+      "company": "segment"
+    }
+  }
+}

--- a/test/fixtures/identify-list-override.json
+++ b/test/fixtures/identify-list-override.json
@@ -32,13 +32,13 @@
       "company": "segment",
       "some-trait": "value",
       "id": "01293721",
-      "$id": "01293721",
       "$email": "bulgogi@bulgogi.com",
       "$first_name": "Mclovin",
       "$last_name": "Spongebob",
       "$phone_number": "123456789",
       "$title": "Mr.Chocolate",
-      "$organization": "org"
+      "$organization": "org",
+      "$id": "01293721"
     },
     "apiKey": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
     "email": "bulgogi@bulgogi.com",

--- a/test/fixtures/identify-list.json
+++ b/test/fixtures/identify-list.json
@@ -26,13 +26,13 @@
       "company": "segment",
       "some-trait": "value",
       "id": "acp0m29",
-      "$id": "acp0m29",
       "$email": "newemail2@email.com",
       "$first_name": "Bender2",
       "$last_name": "Schmender",
       "$phone_number": "123456789",
       "$title": "Mr.Chocolate",
-      "$organization": "org"
+      "$organization": "org",
+      "$id": "acp0m29"
     },
     "apiKey": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
     "email": "newemail2@email.com",

--- a/test/fixtures/track-email-only.json
+++ b/test/fixtures/track-email-only.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "some-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "email": "johndoe@segment.io",
+      "property": true
+    }
+  },
+  "output": {
+    "token": "hfWBjc",
+    "event": "some-event",
+    "time": 1388534400,
+    "customer_properties": {
+      "$email": "johndoe@segment.io"
+    },
+    "properties": {
+      "property": true,
+      "email": "johndoe@segment.io",
+      "revenue": 19.99,
+      "$value": 19.99
+    }
+  }
+}


### PR DESCRIPTION
This is to fix https://github.com/segment-integrations/analytics.js-integration-klaviyo/issues/12

this is a backward compat solution to squash the edge case where klaviyo would create dupes if you send both $id and $email in various messy scenarios where other integrations are at play. It also involves how Klaviyo performs their backend lookups.

Either way, to prevent this issue once and for all for those that are affected, we will provide a UI option that basically lets you never set $id but `id` as a custom attribute. 

We will document that you should only use this if you know its implication.

TODO: 

- [x] mongo migration: https://github.com/segmentio/mongo-scripts/pull/405
- [x] client side pr: https://github.com/segment-integrations/analytics.js-integration-klaviyo/pull/14
- [x] deploy
- [x] metadata update

cc @tsholmes @anoonan @ladanazita @Peripheral1994 @ccnixon 