### PR TITLE
Exclude id

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+1.4.1 / 2017-04-12
+==================
+
+  * Also remove `id` for enforce email option introduced in 1.4.0 
+
 1.4.0 / 2017-04-05
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -53,11 +53,12 @@ exports.track = function(track) {
     properties: properties(track),
     time: time(track.timestamp()),
     customer_properties: {
-      $email: track.email()
+      $email: track.email(),
+      $id: track.userId() || track.anonymousId()
     }
   };
 
-  if (!this.settings.enforceEmail) ret.customer_properties.$id = track.userId() || track.anonymousId()
+  if (this.settings.enforceEmail) remove(ret.customer_properties, '$id');
 
   return ret;
 };
@@ -290,11 +291,13 @@ function properties(track) {
 
 function traits(identify, settings) {
   var traits = identify.traits();
+  // undocumented but klaviyo looks up both $id or id
   // why are we extending and not removing duplicate traits here?
   var ret = extend(traits, {
     $email: identify.email(),
     $first_name: identify.firstName(),
     $last_name: identify.lastName(),
+    $id: identify.userId() || identify.anonymousId(),
     $phone_number: identify.phone(),
     $title: identify.proxy('traits.title') || identify.position(),
     $organization: identify.proxy('traits.organization'),
@@ -304,8 +307,10 @@ function traits(identify, settings) {
     $timezone: identify.timezone(),
     $zip: identify.zip()
   });
-
-  if (!settings.enforceEmail) ret.$id = identify.userId() || identify.anonymousId()
+  if (settings.enforceEmail) {
+    remove(ret, 'id');
+    remove(ret, '$id');
+  }
 
   return reject(ret);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-klaviyo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Klaviyo server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/identify-email-only.json
+++ b/test/fixtures/identify-email-only.json
@@ -45,7 +45,6 @@
         "postalCode": "02818",
         "country": "USA"
       },
-      "id": "hamsolo",
       "email": "hamsolo@gmail.com",
       "firstName": "ham",
       "lastName": "turkey",

--- a/test/fixtures/identify-list-override.json
+++ b/test/fixtures/identify-list-override.json
@@ -35,10 +35,10 @@
       "$email": "bulgogi@bulgogi.com",
       "$first_name": "Mclovin",
       "$last_name": "Spongebob",
+      "$id": "01293721",
       "$phone_number": "123456789",
       "$title": "Mr.Chocolate",
-      "$organization": "org",
-      "$id": "01293721"
+      "$organization": "org"
     },
     "apiKey": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
     "email": "bulgogi@bulgogi.com",

--- a/test/fixtures/identify-list.json
+++ b/test/fixtures/identify-list.json
@@ -29,10 +29,10 @@
       "$email": "newemail2@email.com",
       "$first_name": "Bender2",
       "$last_name": "Schmender",
+      "$id": "acp0m29",
       "$phone_number": "123456789",
       "$title": "Mr.Chocolate",
-      "$organization": "org",
-      "$id": "acp0m29"
+      "$organization": "org"
     },
     "apiKey": "pk_95773fc9a18f5728da58471d70a4dcbcdf",
     "email": "newemail2@email.com",


### PR DESCRIPTION
This should finally put to rest https://github.com/segment-integrations/analytics.js-integration-klaviyo/issues/12

klaviyo has an undocumented lookup where both `$id` and `id` will be used. so if you want to enforce email, we must never set either to prevent the dupe issues.

@tsholmes @segment-integrations/integrations 