### PR TITLE
Add option to have event name parity between client/server for Order Completed | EPD-239

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+1.4.2 / 2017-04-13
+==================
+
+  * Send `Order Completed` instead of `Placed Order` for event name if you set new option to use Segment Ecommerce Spec 
+
 1.4.1 / 2017-04-12
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ Klaviyo.prototype.orderCompleted = function(track, fn) {
           self
             .get('/track')
             .query({ data: encode(product) })
-            .end(self.handle(done));
+            .end(done);
         });
       })
 
@@ -161,11 +161,11 @@ Klaviyo.prototype.orderCompleted = function(track, fn) {
 
 Klaviyo.prototype.check = function(fn){
   var self = this;
-  return this.handle(function(err, res){
+  return function(err, res){
     if (err) return fn(err);
     if (res.text != '1') err = self.error('bad response');
     return fn(err, res);
-  });
+  };
 };
 
 /**

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -83,7 +83,8 @@ exports.orderCompleted = function(track, settings) {
 
   payloads.order = {
     token: settings.apiKey,
-    event: 'Placed Order',
+    // to resolve disparity between client side in least breaking manner
+    event: settings.useSegmentSpec ? 'Order Completed' : 'Placed Order',
     time: time(track.timestamp())
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-klaviyo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Klaviyo server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/track-order-completed-custom.json
+++ b/test/fixtures/track-order-completed-custom.json
@@ -37,7 +37,7 @@
   "output": {
     "order": {
       "token" : "hfWBjc",
-      "event" : "Placed Order",
+      "event" : "Order Completed",
       "customer_properties" : {
         "$id": "hamsolo"
       },

--- a/test/fixtures/track-order-completed-urls.json
+++ b/test/fixtures/track-order-completed-urls.json
@@ -33,7 +33,7 @@
   "output": {
     "order": {
       "token" : "hfWBjc",
-      "event" : "Placed Order",
+      "event" : "Order Completed",
       "customer_properties" : {
         "$id": "user-id"
       },

--- a/test/fixtures/track-order-completed.json
+++ b/test/fixtures/track-order-completed.json
@@ -31,7 +31,7 @@
   "output": {
     "order": {
       "token" : "hfWBjc",
-      "event" : "Placed Order",
+      "event" : "Order Completed",
       "customer_properties" : {
         "$id": "user-id"
       },

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ describe('Klaviyo', function () {
       listId: 'baVTu8',
       sendAnonymous: true,
       enforceEmail: false,
-      useSegmentSpec: false
+      useSegmentSpec: true
     };
     klaviyo = new Klaviyo(settings);
     test = Test(klaviyo, __dirname);
@@ -140,8 +140,10 @@ describe('Klaviyo', function () {
     });
 
     describe('.completedOrder()', function(){
-      it('should successfully send the Placed Order event', function(done){
+      it('should successfully send the Placed Order event if segment spec is disabled', function(done){
+        klaviyo.settings.useSegmentSpec = false;
         var json = test.fixture('track-order-completed');
+        json.output.order.event = 'Placed Order';
 
         test
           .set(settings)
@@ -153,9 +155,7 @@ describe('Klaviyo', function () {
       });
 
       it('should successfully send the Order Completed event if using segment spec', function(done){
-        klaviyo.settings.useSegmentSpec = true;
         var json = test.fixture('track-order-completed');
-        json.output.order.event = 'Order Completed';
 
         test
           .set(settings)

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ describe('Klaviyo', function () {
       listId: 'baVTu8',
       sendAnonymous: true,
       enforceEmail: false,
+      useSegmentSpec: false
     };
     klaviyo = new Klaviyo(settings);
     test = Test(klaviyo, __dirname);
@@ -141,6 +142,20 @@ describe('Klaviyo', function () {
     describe('.completedOrder()', function(){
       it('should successfully send the Placed Order event', function(done){
         var json = test.fixture('track-order-completed');
+
+        test
+          .set(settings)
+          .track(json.input)
+          .request(0)
+          .query('data', json.output.order, decode)
+          .expects(200)
+          .end(done);
+      });
+
+      it('should successfully send the Order Completed event if using segment spec', function(done){
+        klaviyo.settings.useSegmentSpec = true;
+        var json = test.fixture('track-order-completed');
+        json.output.order.event = 'Order Completed';
 
         test
           .set(settings)


### PR DESCRIPTION
Klaviyo docs on how one should send ecommerce events are _NOT_ enforced spec but more so... guidelines. Klaviyo's API does not treat event names in semantic manner like Segment does.

Right now there is disparity between the client + server side because the client side sends `'Order Completed'` while server side sends `'Placed Order'` for event name when you send an order completed event.

Since Klaviyo spec is not a true enforced spec, I want to just use our Segment spec. We will still transform the payload properties to match Klaviyo docs but I do not believe it is worth doing a big migration with customer comms just to change the event names when in fact, they do not matter inside Klaviyo.

So, this PR adds a new option for users to simply _always_ send `Order Completed` so that both client and server side will be in sync. We can talk about deprecating the old event name for Placed Order if needed sometime in the future.

For people who currently don't care about this disparity and would rather not break any existing reports, they don't have to take any action.

This should close https://github.com/segment-integrations/analytics.js-integration-klaviyo/issues/11

@tsholmes @segment-integrations/integrations 