### PR TITLE
Added functions to check and un-suppress a profile if needed.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,14 +95,26 @@ Klaviyo.prototype._addToList = function(data, fn) {
 
 Klaviyo.prototype._subscribeToList = function(data, fn) {
   this
-    .post('/v2/list/' + data.listId + '/subscribe')
+    .post('/api/profile-subscription-bulk-create-jobs/')
     .type('form')
     .send({
-      email: data.email,
-      api_key: data.apiKey,
-      confirm_optin: data.confirmOptIn,
+      type: 'profile-subscription-bulk-create-job',
+      attributes: {
+        list_id: data.listId,
+        subscriptions: [
+          {
+            channels: {
+              email: [
+                'MARKETING'
+              ]
+            },
+            email: data.email
+          }
+        ]
+      }
       properties: JSON.stringify(data.properties)
-    })
+    }
+    )
     .end(fn);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,14 @@ Klaviyo.prototype.identify = function(data, fn) {
   // add to list. this call will also create or update new/existing users
   // basically a superset of the identify call
   if (data.listId && data.email && data.apiKey) {
+    // check if the subscriber already exists and is suppressed
+    // if suppressed, then a separate subscribe endpoint is needed
+    data.profileId = this._getProfileId(data, fn);
+    var consent = this._getProfile(data, fn);
+    if (consent) {
+      this._subscribeToList(data, fn);
+    }
+    // regardless of existing or suppressed status, always add to list the regular way
     return this._addToList(data, fn);
   }
 
@@ -72,6 +80,73 @@ Klaviyo.prototype._addToList = function(data, fn) {
       properties: JSON.stringify(data.properties)
     })
     .end(fn);
+};
+
+/**
+ * Subscribe to list.
+ * This is needed in order for the profile to be un-suppressed if suppressed
+ *
+ * https://developers.klaviyo.com/en/v1-2/reference/subscribe
+ *
+ * @param {Object} data
+ * @param {Function} fn
+ * @api public
+ */
+
+Klaviyo.prototype._subscribeToList = function(data, fn) {
+  this
+    .post('/v2/list/' + data.listId + '/subscribe')
+    .type('form')
+    .send({
+      email: data.email,
+      api_key: data.apiKey,
+      confirm_optin: data.confirmOptIn,
+      properties: JSON.stringify(data.properties)
+    })
+    .end(fn);
+};
+
+/**
+ * Find a profile
+ *
+ *  https://developers.klaviyo.com/en/v1-2/reference/get-profile-id
+ *
+ * @param {Object} data
+ * @param {Function} fn
+ * @api public
+ */
+
+Klaviyo.prototype._getProfileId = function(data, fn) {
+  return this
+    .post('/v2/people/search')
+    .type('form')
+    .send({
+      email: data.email,
+      api_key: data.apiKey
+    })
+    .end(fn);
+};
+
+/**
+ * Get profile
+ *
+ *  https://developers.klaviyo.com/en/v1-2/reference/get-profile
+ *
+ * @param {Object} data
+ * @param {Function} fn
+ * @api public
+ */
+
+Klaviyo.prototype._getProfile = function(data, fn) {
+  let profile = this
+    .post('/v1/person/' + data.profileId)
+    .type('form')
+    .send({
+      api_key: data.apiKey
+    })
+    .end(fn);
+
+  return profile.data.$consent;
 };
 
 /**


### PR DESCRIPTION
Currently, `_addToList` does not un-suppress a profile if it's suppressed. This is very problematic for our project.

A solution is to first find the profile, check if suppressed, and if so -> then we un-suppress the profile via the v2 endpoint subscribe to list (according to Klaviyo recommendation).